### PR TITLE
Update the logged end time to match the time used in the copy to clipboard button.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.22'
+def runeLiteVersion = '1.7.24'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.8.1'
+def runeLiteVersion = '1.7.22'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.24'
+def runeLiteVersion = '1.8.7.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/infernostats/InfernoStatsConfig.java
+++ b/src/main/java/com/infernostats/InfernoStatsConfig.java
@@ -318,4 +318,48 @@ public interface InfernoStatsConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigSection(
+			name = "Idle ticks",
+			description = "Settings around tracking player idle ticks",
+			position = 5,
+			closedByDefault = true
+	)
+	String idleTicks = "idleTicks";
+
+	@ConfigItem(
+			keyName = "trackIdleTicks",
+			name = "Track idle ticks",
+			description = "Track idle ticks, where the player is not attacking a live NPC",
+			position = 1,
+			section=idleTicks
+	)
+	default boolean trackIdleTicks()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "showIdleTicksInSidepanel",
+			name = "Show idle ticks in sidepanel",
+			description = "Show idle ticks in the side panel",
+			position = 2,
+			section = idleTicks
+	)
+	default boolean showIdleTicksInSidepanel()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "showIdleTicksInChatbox",
+			name = "Show idle ticks in chatbox",
+			description = "Show idle ticks in the chat box",
+			position = 3,
+			section = idleTicks
+	)
+	default boolean showIdleTicksInChatbox()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/infernostats/InfernoStatsConfig.java
+++ b/src/main/java/com/infernostats/InfernoStatsConfig.java
@@ -329,9 +329,9 @@ public interface InfernoStatsConfig extends Config
 
 	@ConfigItem(
 			keyName = "trackIdleTicks",
-			name = "Track idle ticks",
+			name = "Track Idle Ticks",
 			description = "Track idle ticks, where the player is not attacking a live NPC",
-			position = 1,
+			position = 0,
 			section=idleTicks
 	)
 	default boolean trackIdleTicks()
@@ -340,13 +340,13 @@ public interface InfernoStatsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showIdleTicksInSidepanel",
+			keyName = "showIdleTicksInSidePanel",
 			name = "Show idle ticks in sidepanel",
 			description = "Show idle ticks in the side panel",
-			position = 2,
+			position = 1,
 			section = idleTicks
 	)
-	default boolean showIdleTicksInSidepanel()
+	default boolean showIdleTicksInSidePanel()
 	{
 		return true;
 	}
@@ -355,7 +355,7 @@ public interface InfernoStatsConfig extends Config
 			keyName = "showIdleTicksInChatbox",
 			name = "Show idle ticks in chatbox",
 			description = "Show idle ticks in the chat box",
-			position = 3,
+			position = 2,
 			section = idleTicks
 	)
 	default boolean showIdleTicksInChatbox()

--- a/src/main/java/com/infernostats/InfernoStatsPlugin.java
+++ b/src/main/java/com/infernostats/InfernoStatsPlugin.java
@@ -253,12 +253,11 @@ public class InfernoStatsPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		tickCounter.onGameTick(client, event);
-		// TODO(Supalosa): Move this up.
 		if (!isInInferno())
 		{
 			return;
 		}
+		tickCounter.onGameTick(client, event);
 
 		Wave wave = GetCurrentWave();
 		if (wave != null)
@@ -326,12 +325,11 @@ public class InfernoStatsPlugin extends Plugin
 
 	@Subscribe
 	public void onAnimationChanged(AnimationChanged e) {
-		tickCounter.onAnimationChanged(client, e);
-		// TODO(Supalosa): Move this up.
 		if (!isInInferno())
 		{
 			return;
 		}
+		tickCounter.onAnimationChanged(client, e);
 	}
 
 	@Subscribe

--- a/src/main/java/com/infernostats/InfernoStatsPlugin.java
+++ b/src/main/java/com/infernostats/InfernoStatsPlugin.java
@@ -43,7 +43,7 @@ import static net.runelite.api.Skill.PRAYER;
 import static net.runelite.api.ItemID.INFERNAL_CAPE;
 
 @PluginDescriptor(
-		name = "Inferno Stats2",
+		name = "Inferno Stats",
 		description = "Track restoration specials during an inferno attempt.",
 		tags = {"combat", "npcs", "overlay"},
 		enabledByDefault = false

--- a/src/main/java/com/infernostats/InfernoStatsPlugin.java
+++ b/src/main/java/com/infernostats/InfernoStatsPlugin.java
@@ -253,13 +253,14 @@ public class InfernoStatsPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
+		tickCounter.onGameTick(client, event);
+		// TODO(Supalosa): Move this up.
 		if (!isInInferno())
 		{
 			return;
 		}
 
 		Wave wave = GetCurrentWave();
-		tickCounter.onGameTick(client, event);
 		if (wave != null)
 		{
 			if (config.trackIdleTicks()) {
@@ -326,6 +327,11 @@ public class InfernoStatsPlugin extends Plugin
 	@Subscribe
 	public void onAnimationChanged(AnimationChanged e) {
 		tickCounter.onAnimationChanged(client, e);
+		// TODO(Supalosa): Move this up.
+		if (!isInInferno())
+		{
+			return;
+		}
 	}
 
 	@Subscribe
@@ -451,7 +457,7 @@ public class InfernoStatsPlugin extends Plugin
 			panel.updateWave(wave);
 
 			if (config.trackIdleTicks() && config.showIdleTicksInChatbox()) {
-				writeIdleTicksToChatbox();
+				writeTotalIdleTicksToChatbox();
 			}
 
 			if (config.saveWaveTimes())
@@ -489,7 +495,7 @@ public class InfernoStatsPlugin extends Plugin
 			panel.updateWave(wave);
 
 			if (config.trackIdleTicks() && config.showIdleTicksInChatbox()) {
-				writeIdleTicksToChatbox();
+				writeTotalIdleTicksToChatbox();
 			}
 
 			if (config.saveWaveTimes())
@@ -616,10 +622,10 @@ public class InfernoStatsPlugin extends Plugin
 		}
 	}
 
-	private void writeIdleTicksToChatbox() {
+	private void writeTotalIdleTicksToChatbox() {
 		final ChatMessageBuilder chatMessageBuilder = new ChatMessageBuilder()
 				.append(ChatColorType.HIGHLIGHT)
-				.append("Total ticks idle: " + waveHistory.getTotalIdleTicks());
+				.append("Total idle ticks in run: " + waveHistory.getTotalIdleTicks());
 		chatMessageManager.queue(
 				QueuedMessage.builder()
 						.type(ChatMessageType.CONSOLE)

--- a/src/main/java/com/infernostats/tickcounter/TickCounter.java
+++ b/src/main/java/com/infernostats/tickcounter/TickCounter.java
@@ -1,0 +1,167 @@
+package com.infernostats.tickcounter;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.infernostats.InfernoStatsConfig;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.MenuAction;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.events.OverlayMenuClicked;
+import net.runelite.api.kit.KitType;
+import net.runelite.client.eventbus.Subscribe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+public class TickCounter
+{
+	private static final Logger logger = LoggerFactory.getLogger(TickCounter.class);
+
+	public static final int BLOWPIPE_TICKS = 2;
+
+	private InfernoStatsConfig config;
+
+	private int idleTicks = 0;
+	private int idleTickStartTimer = 0;
+	Set<Integer> attackableNpcs = new HashSet<>();
+	// The onAnimationChanged event does not fire during Rapid blowpiping as the animation is 3 ticks long so it simply
+	// repeats. Therefore we simply store whether the blowpipe is being fired or not and infer from the animation frame
+	// if it's being fired at 2t or 3t.
+	private boolean isBlowpiping = false;
+
+	boolean instanced = false;
+	boolean prevInstance = false;
+
+	public TickCounter(InfernoStatsConfig config) {
+		this.config = config;
+	}
+
+	public void onAnimationChanged(Client client, AnimationChanged e)
+	{
+		if (!config.trackIdleTicks())
+			return;
+		if (!(e.getActor() instanceof Player))
+			return;
+		Player p = (Player) e.getActor();
+		int weapon = -1;
+		if (p.getPlayerComposition() != null)
+			weapon = p.getPlayerComposition().getEquipmentId(KitType.WEAPON);
+		int animation = p.getAnimation();
+		// Get default ticks for the animation + weapon combination.
+		int delta = TickCounterUtils.getTicksForAnimation(animation, weapon);
+		// Handle special cases.
+		switch (animation)
+		{
+			case 7617: // rune knife
+			case 8194: // dragon knife
+			case 8291: // dragon knife spec
+			case 5061: // blowpipe
+				if (weapon == 12926)
+				{
+					delta = 0;
+					isBlowpiping = true;
+					logger.info("{} BP animation start", client.getTickCount());
+				}
+				break;
+			case -1:
+				isBlowpiping = false;
+				logger.info("{} Clear blowpipe animation state", client.getTickCount());
+				break;
+		}
+		if (delta > 0)
+		{
+			// Store the tick the player should be able to attack again.
+			this.idleTickStartTimer = client.getTickCount() + delta;
+		}
+	}
+
+	public void onGameTick(Client client, GameTick tick)
+	{
+		if (config.trackIdleTicks() && client.getTickCount() > idleTickStartTimer) {
+			Set<Integer> oldAttackableNpcs = attackableNpcs;
+			attackableNpcs = getNearbyAttackableNpcs(client);
+			// If there were any NPCs that were attackable in the previous tick that are still attackable now, then
+			// we lost a tick. This avoids counting missed ticks when the first NPC spawns (since you can't attack on
+			// the same tick).
+			if (oldAttackableNpcs != null) {
+				Set<Integer> intersection = Sets.intersection(oldAttackableNpcs, attackableNpcs);
+				if (intersection.size() > 0) {
+					log.info("{} idle tick", client.getTickCount());
+					++this.idleTicks;
+				}
+			}
+		}
+		if (isBlowpiping && client.getLocalPlayer().getAnimationFrame() == 0)
+		{
+			idleTickStartTimer = client.getTickCount() + BLOWPIPE_TICKS;
+			logger.info("{} BP animation started, +2 ticks ", client.getTickCount());
+		}
+		prevInstance = instanced;
+		instanced = client.isInInstancedRegion();
+		if (!prevInstance && instanced)
+		{
+			clearState();
+		}
+	}
+
+	public void startIdleTimer(int clientTick) {
+		idleTickStartTimer = clientTick;
+	}
+
+	public int getIdleTicks() {
+		return idleTicks;
+	}
+
+	public void clearState() {
+		idleTicks = 0;
+		idleTickStartTimer = Integer.MAX_VALUE;
+		isBlowpiping = false;
+		attackableNpcs.clear();
+	}
+
+	/**
+	 * Returns a hashset of attackable NPCs nearby. Does not include NPCs that are at zero HP.
+	 *
+	 * @param client Client to query on.
+	 * @return Set of IDs of nearby attackable NPCs.
+	 */
+	private static Set<Integer> getNearbyAttackableNpcs(Client client) {
+		Set<Integer> result = new HashSet<>();
+		if (!client.getNpcs().isEmpty()) {
+			client.getNpcs().stream().filter(npc -> {
+				return !npc.isDead() && isAttackable(npc);
+			}).forEach(npc -> result.add(npc.getId()));
+		}
+		return result;
+	}
+
+	private static boolean isAttackable(NPC npc) {
+		for (int i = 0; i < npc.getComposition().getActions().length; ++i) {
+			String action = npc.getComposition().getActions()[i];
+			if (action != null && action.equals("Attack")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Subscribe
+	public void onOverlayMenuClicked(OverlayMenuClicked event)
+	{
+		if (event.getEntry().getMenuAction() == MenuAction.RUNELITE_OVERLAY &&
+			event.getEntry().getTarget().equals("Tick counter") &&
+			event.getEntry().getOption().equals("Reset"))
+		{
+			clearState();
+		}
+	}
+
+}

--- a/src/main/java/com/infernostats/tickcounter/TickCounter.java
+++ b/src/main/java/com/infernostats/tickcounter/TickCounter.java
@@ -4,19 +4,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import com.google.common.collect.Sets;
 import com.infernostats.InfernoStatsConfig;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
-import net.runelite.api.MenuAction;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameTick;
-import net.runelite.client.events.OverlayMenuClicked;
 import net.runelite.api.kit.KitType;
-import net.runelite.client.eventbus.Subscribe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,12 +64,12 @@ public class TickCounter
 				{
 					delta = 0;
 					isBlowpiping = true;
-					logger.info("{} BP animation start", client.getTickCount());
+					logger.debug("{} BP animation start", client.getTickCount());
 				}
 				break;
 			case -1:
 				isBlowpiping = false;
-				logger.info("{} Clear blowpipe animation state", client.getTickCount());
+				logger.debug("{} Clear blowpipe animation state", client.getTickCount());
 				break;
 		}
 		if (delta > 0)
@@ -94,7 +90,7 @@ public class TickCounter
 			if (oldAttackableNpcs != null) {
 				Set<Integer> intersection = Sets.intersection(oldAttackableNpcs, attackableNpcs);
 				if (intersection.size() > 0) {
-					log.info("{} idle tick", client.getTickCount());
+					log.debug("{} idle tick", client.getTickCount());
 					++this.idleTicks;
 				}
 			}
@@ -102,7 +98,7 @@ public class TickCounter
 		if (isBlowpiping && client.getLocalPlayer().getAnimationFrame() == 0)
 		{
 			idleTickStartTimer = client.getTickCount() + BLOWPIPE_TICKS;
-			logger.info("{} BP animation started, +2 ticks ", client.getTickCount());
+			logger.debug("{} BP animation started, +2 ticks ", client.getTickCount());
 		}
 		prevInstance = instanced;
 		instanced = client.isInInstancedRegion();
@@ -152,16 +148,4 @@ public class TickCounter
 		}
 		return false;
 	}
-
-	@Subscribe
-	public void onOverlayMenuClicked(OverlayMenuClicked event)
-	{
-		if (event.getEntry().getMenuAction() == MenuAction.RUNELITE_OVERLAY &&
-			event.getEntry().getTarget().equals("Tick counter") &&
-			event.getEntry().getOption().equals("Reset"))
-		{
-			clearState();
-		}
-	}
-
 }

--- a/src/main/java/com/infernostats/tickcounter/TickCounter.java
+++ b/src/main/java/com/infernostats/tickcounter/TickCounter.java
@@ -91,7 +91,7 @@ public class TickCounter
 	{
 		Player player = client.getLocalPlayer();
 		int weaponId = player.getPlayerComposition().getEquipmentId(KitType.WEAPON);
-		log.info("{} Player is holding weapon {}", client.getTickCount(), weaponId);
+		log.debug("{} Player is holding weapon {}", client.getTickCount(), weaponId);
 		if (animationUpdate.isPresent()) {
 			handleAnimationChange(client, animationUpdate.get(), weaponId);
 			animationUpdate = Optional.empty();
@@ -133,7 +133,7 @@ public class TickCounter
 	}
 
 	public void clearState() {
-		log.info("Clearing state for TickCounter");
+		log.debug("Clearing state for TickCounter");
 		idleTicks = 0;
 		idleTickStartTimer = Integer.MAX_VALUE;
 		isBlowpiping = false;

--- a/src/main/java/com/infernostats/tickcounter/TickCounter.java
+++ b/src/main/java/com/infernostats/tickcounter/TickCounter.java
@@ -16,6 +16,9 @@ import net.runelite.api.kit.KitType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Adapted from https://github.com/winterdaze/tick-counter but changed to track only a single player.
+ */
 @Slf4j
 public class TickCounter
 {

--- a/src/main/java/com/infernostats/tickcounter/TickCounterUtils.java
+++ b/src/main/java/com/infernostats/tickcounter/TickCounterUtils.java
@@ -1,0 +1,120 @@
+package com.infernostats.tickcounter;
+
+public class TickCounterUtils {
+    public static int getTicksForAnimation(int animation, int weapon) {
+        int delta;
+        switch (animation)
+        {
+            case 7617: // rune knife
+            case 8194: // dragon knife
+            case 8291: // dragon knife spec
+            case 5061: // blowpipe
+                delta = 2;
+                break;
+            case 2323: // rpg
+            case 7618: // chin
+                delta = 3;
+                break;
+            case 426: // bow shoot
+                if (weapon == 20997) // twisted bow
+                    delta = 5;
+                else // shortbow
+                    delta = 3;
+                break;
+            case 376: // dds poke
+            case 377: // dds slash
+            case 422: // punch
+            case 423: // kick
+            case 386: // lunge
+            case 390: // generic slash
+                if (weapon == 24219) // swift blade
+                {
+                    delta = 3;
+                    break;
+                }
+            case 1062: // dds spec
+            case 1067: // claw stab
+            case 1074: // msb spec
+            case 1167: // trident cast
+            case 1658: // whip
+            case 2890: // arclight spec
+            case 3294: // abby dagger slash
+            case 3297: // abby dagger poke
+            case 3298: // bludgeon attack
+            case 3299: // bludgeon spec
+            case 3300: // abby dagger spec
+            case 7514: // claw spec
+            case 7515: // d sword spec
+            case 8145: // rapier stab
+            case 8288: // dhl stab
+                if (weapon == 24219) // swift blade
+                {
+                    delta = 3;
+                    break;
+                }
+            case 8289: // dhl slash
+            case 8290: // dhl crush
+            case 4503: // inquisitor's mace crush
+            case 1711: // zamorakian spear
+                delta = 4;
+                break;
+            case 393: // staff bash
+                if (weapon == 13652)
+                { // claw scratch
+                    delta = 4;
+                    break;
+                }
+            case 395: // axe autos
+            case 400: // pick smash
+                if (weapon == 24417)
+                {
+                    // inquisitor's mace stab
+                    delta = 4;
+                    break;
+                }
+            case 1379: // burst or blitz
+            case 1162: // strike/bolt spells
+            case 7855: // surge spells
+                if (weapon == 24423) // harmonised staff
+                {
+                    delta = 4;
+                    break;
+                }
+            case 7552: // generic crossbow
+            case 1979: // barrage spell cast
+            case 8056: // scythe swing
+                delta = 5;
+                break;
+            case 401:
+                if (weapon == 13576) // dwh bop
+                    delta = 6;
+                else if (weapon == 23360) // ham joint
+                    delta = 3;
+                else // used by pickaxe and axe
+                    delta = 5;
+                break;
+            case 1378:
+            case 7045:
+            case 7054:
+            case 7055: // godsword autos
+            case 7511: // dinh's attack
+            case 7516: // maul attack
+            case 7555: // ballista attack
+            case 7638: // zgs spec
+            case 7640: // sgs spec
+            case 7642: // bgs spec
+            case 7643: // bgs spec
+            case 7644: // ags spec
+                delta = 6;
+                break;
+            case 428: // chally swipe
+            case 440: // chally jab
+            case 1203: // chally spec
+                delta = 7;
+                break;
+            default:
+                delta = 0;
+        }
+        return delta;
+    }
+}

--- a/src/main/java/com/infernostats/tickcounter/TickCounterUtils.java
+++ b/src/main/java/com/infernostats/tickcounter/TickCounterUtils.java
@@ -1,6 +1,15 @@
 package com.infernostats.tickcounter;
 
 public class TickCounterUtils {
+    /**
+     * Returns the number of ticks that an animation and/or weapon takes to attack with.
+     *
+     * Adapted from https://github.com/winterdaze/tick-counter
+     *
+     * @param animation The ID of the animation.
+     * @param weapon The ID of the weapon.
+     * @return Number of ticks for the given animation/weapon combination.
+     */
     public static int getTicksForAnimation(int animation, int weapon) {
         int delta;
         switch (animation)

--- a/src/main/java/com/infernostats/wavehistory/Wave.java
+++ b/src/main/java/com/infernostats/wavehistory/Wave.java
@@ -39,6 +39,7 @@ public class Wave {
     public Instant stopTime;
     public Duration splitTime;
     public Duration predictedTime;
+    public Duration waveEndSplit;
     public boolean forceReset;
     public int idleTicks = 0;
 
@@ -82,8 +83,9 @@ public class Wave {
         this.forceReset = false;
     }
 
-    public void Finished(boolean failed)
+    public void Finished(Duration waveEndSplit, boolean failed)
     {
+        this.waveEndSplit = waveEndSplit;
         this.failed = failed;
         stopTime = Instant.now();
     }

--- a/src/main/java/com/infernostats/wavehistory/Wave.java
+++ b/src/main/java/com/infernostats/wavehistory/Wave.java
@@ -187,7 +187,7 @@ public class Wave {
 
         StringBuilder sb = new StringBuilder();
 
-        sb.append("https://infernostats.github.io/inferno.html?");
+        sb.append("https://www.infernotrainer.com/?");
         for (Map.Entry<String, ArrayList<ArrayList<Integer>>> entry : mobs.entrySet())
         {
             sb.append(npc_names.get(entry.getKey()));

--- a/src/main/java/com/infernostats/wavehistory/Wave.java
+++ b/src/main/java/com/infernostats/wavehistory/Wave.java
@@ -40,6 +40,7 @@ public class Wave {
     public Duration splitTime;
     public Duration predictedTime;
     public boolean forceReset;
+    public int idleTicks = 0;
 
     private static final List<Integer> SPLIT_WAVES = new ArrayList<Integer>() {{
         add(9);

--- a/src/main/java/com/infernostats/wavehistory/Wave.java
+++ b/src/main/java/com/infernostats/wavehistory/Wave.java
@@ -195,8 +195,7 @@ public class Wave {
             sb.append(entry.getValue());
             sb.append("&");
         }
-        sb.deleteCharAt(sb.length()-1); // Remove trailing ampersand
-
+        sb.append("copyable");
         return sb.toString().replaceAll("\\s", "");
     }
 }

--- a/src/main/java/com/infernostats/wavehistory/WaveHistory.java
+++ b/src/main/java/com/infernostats/wavehistory/WaveHistory.java
@@ -2,6 +2,7 @@ package com.infernostats.wavehistory;
 
 import com.google.inject.Inject;
 import com.infernostats.InfernoStatsConfig;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.NPC;
 import net.runelite.api.coords.WorldPoint;
 import org.apache.commons.lang3.StringUtils;
@@ -12,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 public class WaveHistory {
     private InfernoStatsConfig config;
     public static List<Wave> waves;
@@ -72,7 +74,9 @@ public class WaveHistory {
             }
         }
         Wave lastWave = waves.get(waves.size() - 1);
-        csv.append("end," + lastWave.SplitTimeString() + "," + lastWave.SplitTimeString());
+        log.debug("Final wave SplitTimeString: {}, CurrentTimeString: {}", lastWave.SplitTimeString(),
+                lastWave.CurrentTimeString());
+        csv.append("end," + lastWave.CurrentTimeString() + "," + lastWave.CurrentTimeString());
         if(config.trackIdleTicks()) {
             csv.append("," + getTotalIdleTicks());
         }

--- a/src/main/java/com/infernostats/wavehistory/WaveHistoryPanel.java
+++ b/src/main/java/com/infernostats/wavehistory/WaveHistoryPanel.java
@@ -56,7 +56,7 @@ public class WaveHistoryPanel extends PluginPanel {
     {
         SwingUtilities.invokeLater(() ->
         {
-            WaveStatsPanel waveStatsPanel = new WaveStatsPanel(wave);
+            WaveStatsPanel waveStatsPanel = new WaveStatsPanel(config, wave);
             waveStatsPanels.add(waveStatsPanel);
             waveHistoryContainer.add(waveStatsPanel, 0);
             updateUI();
@@ -77,6 +77,7 @@ public class WaveHistoryPanel extends PluginPanel {
                     panel.damageTaken.setText("Damage Taken: " + wave.damageTaken);
                     panel.prayerDrain.setText("Prayer Drain: " + wave.prayerDrain);
                     panel.damageDealt.setText("Damage Dealt: " + wave.damageDealt);
+                    panel.idleTicks.setText("Idle ticks: " + wave.idleTicks);
                     panel.RedrawWaveSpawn();
                 }
             }

--- a/src/main/java/com/infernostats/wavehistory/WaveHistoryPanel.java
+++ b/src/main/java/com/infernostats/wavehistory/WaveHistoryPanel.java
@@ -77,7 +77,7 @@ public class WaveHistoryPanel extends PluginPanel {
                     panel.damageTaken.setText("Damage Taken: " + wave.damageTaken);
                     panel.prayerDrain.setText("Prayer Drain: " + wave.prayerDrain);
                     panel.damageDealt.setText("Damage Dealt: " + wave.damageDealt);
-                    panel.idleTicks.setText("Idle ticks: " + wave.idleTicks);
+                    panel.idleTicks.setText("Idle Ticks: " + wave.idleTicks);
                     panel.RedrawWaveSpawn();
                 }
             }

--- a/src/main/java/com/infernostats/wavehistory/WaveStatsPanel.java
+++ b/src/main/java/com/infernostats/wavehistory/WaveStatsPanel.java
@@ -1,5 +1,6 @@
 package com.infernostats.wavehistory;
 
+import com.infernostats.InfernoStatsConfig;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.ImageUtil;
@@ -28,8 +29,10 @@ public class WaveStatsPanel extends JPanel {
     public JLabel damageTaken;
     public JLabel prayerDrain;
     public JLabel damageDealt;
+    public JLabel idleTicks;
     public WaveImage imageLabel;
     private JPanel textPanel;
+    private InfernoStatsConfig config;
     private boolean repainted = false;
 
     private static final Border normalBorder = BorderFactory.createCompoundBorder(
@@ -42,7 +45,7 @@ public class WaveStatsPanel extends JPanel {
                         BorderFactory.createLineBorder(ColorScheme.DARKER_GRAY_HOVER_COLOR),
                         new EmptyBorder(3, 5, 3, 5)));
 
-    public WaveStatsPanel(Wave wave)
+    public WaveStatsPanel(InfernoStatsConfig config, Wave wave)
     {
         this.wave = wave;
         serializedLineOfSight = wave.SerializeWave();
@@ -120,10 +123,22 @@ public class WaveStatsPanel extends JPanel {
         damageDealt.setForeground(Color.WHITE);
         damageDealtLine.add(damageDealt, BorderLayout.WEST);
 
+        JPanel idleTicksLine = new JPanel();
+        idleTicksLine.setLayout(new BorderLayout());
+        idleTicksLine.setBackground(null);
+
+        idleTicks = new JLabel();
+        idleTicks.setText("Idle ticks: " + wave.idleTicks);
+        idleTicks.setForeground(Color.WHITE);
+        if (config.trackIdleTicks() && config.showIdleTicksInSidepanel()) {
+            idleTicksLine.add(idleTicks, BorderLayout.WEST);
+        }
+
         textPanel.add(durationLine);
         textPanel.add(damageTakenLine);
         textPanel.add(prayerDrainLine);
         textPanel.add(damageDealtLine);
+        textPanel.add(idleTicksLine);
 
         JPanel imagePanel = new JPanel();
         imagePanel.setLayout(new BoxLayout(imagePanel, BoxLayout.Y_AXIS));

--- a/src/main/java/com/infernostats/wavehistory/WaveStatsPanel.java
+++ b/src/main/java/com/infernostats/wavehistory/WaveStatsPanel.java
@@ -128,9 +128,9 @@ public class WaveStatsPanel extends JPanel {
         idleTicksLine.setBackground(null);
 
         idleTicks = new JLabel();
-        idleTicks.setText("Idle ticks: " + wave.idleTicks);
+        idleTicks.setText("Idle Ticks: " + wave.idleTicks);
         idleTicks.setForeground(Color.WHITE);
-        if (config.trackIdleTicks() && config.showIdleTicksInSidepanel()) {
+        if (config.trackIdleTicks() && config.showIdleTicksInSidePanel()) {
             idleTicksLine.add(idleTicks, BorderLayout.WEST);
         }
 


### PR DESCRIPTION
This fixes the logged file showing the 'end' time as the start of the wave instead of the end of the run.